### PR TITLE
feat: trigger builds for multiple builds per branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The `BITRISE_ACCESS_TOKEN` variable needs to be defined in the environment where
 | :---------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- | :------------------------------------------- |
 | `appSlug`     | The AppSlug from bitrise                                                                                                                                  | yes       | - |
 | `workflowId` | Sets the id of the workflow to run on bitrise. If none given the default trigger map will be used | no       | -                                         |
-| `workflowIdMap` | Sets the id of the workflow to run on bitrise based on a branch. If none given the default trigger map will be used | no       | -                                         |
+| `workflowIdMap` | Sets the id of the workflows to run on bitrise based on a branch. If none given the default trigger map will be used | no       | -                                         |
 
 ## Examples
 

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -1,5 +1,5 @@
 export interface Config {
 	appSlug: string,
 	workflowId?: string,
-	workflowIdMap?: Record<string, string>
+	workflowIdMap?: Record<string, string | string[]>
 }


### PR DESCRIPTION
This is a follow up PR for https://github.com/BerniWittmann/semantic-release-bitrise/pull/2 and addressed the change requests.

In some cases we want to trigger multiple workflows per branch. This PR adapts the configuration to allow specifying multiple workflows to be triggered after a semantic release run.